### PR TITLE
Add face for `helm-buffer-directory`

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -153,6 +153,7 @@
    `(helm-buffer-process ((t (:foreground ,atom-one-dark-mono-2))))
    `(helm-buffer-saved-out ((t (:foreground ,atom-one-dark-fg))))
    `(helm-buffer-size ((t (:foreground ,atom-one-dark-mono-2))))
+   `(helm-buffer-directory ((t (:foreground ,atom-one-dark-purple))))
    `(helm-grep-cmd-line ((t (:foreground ,atom-one-dark-cyan))))
    `(helm-grep-file ((t (:foreground ,atom-one-dark-fg))))
    `(helm-grep-finish ((t (:foreground ,atom-one-dark-green))))


### PR DESCRIPTION
I always have open `dired` buffers, so I want them to look good in my `(helm-buffers-list)`. :wink:
This style matches the foreground color of `dired-directory`.
