### PR TITLE
Change constant face colors to match Atom

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -75,7 +75,7 @@
    `(font-lock-preprocessor-face ((t (:foreground ,atom-one-dark-mono-2))))
    `(font-lock-string-face ((t (:foreground ,atom-one-dark-green))))
    `(font-lock-type-face ((t (:foreground ,atom-one-dark-orange-2))))
-   `(font-lock-constant-face ((t (:foreground ,atom-one-dark-orange-1))))
+   `(font-lock-constant-face ((t (:foreground ,atom-one-dark-cyan))))
    `(font-lock-variable-name-face ((t (:foreground ,atom-one-dark-red-1))))
    `(font-lock-warning-face ((t (:foreground ,atom-one-dark-mono-3 :bold t))))
 


### PR DESCRIPTION
Symbols in Ruby are colored cyan in Atom. This sets
constant face to the corresponding cyan
