### PR TITLE
js2-mode: Fix function parameter colors

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -174,6 +174,9 @@
    `(git-commit-comment-branch  ((t (:foreground ,atom-one-dark-blue :weight bold))))
    `(git-commit-comment-heading ((t (:foreground ,atom-one-dark-orange-2 :weight bold))))
 
+   ;; js2-mode
+   `(js2-function-param ((t (:foreground ,atom-one-dark-mono-1))))
+
    ;; magit
    `(magit-section-highlight ((t (:background ,atom-one-dark-bg-hl))))
    `(magit-section-heading ((t (:foreground ,atom-one-dark-orange-2 :weight bold))))


### PR DESCRIPTION
There is currently no `js2-mode` support and so there are colors being set by `js2-mode` that are making it through instead of being styled by this package.  This commit includes the only deviation I can find right now, which is function parameters.  `js2-mode` sets the `js2-function-param` face to `SeaGreen` but it should be `atom-one-dark-mono-1` based on what Atom itself uses.

This commit does not add comprehensive `js2-mode` support but I did go through and look for discrepancies and only found this one.
