### PR TITLE
js2-mode: Initial support

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -174,6 +174,14 @@
    `(git-commit-comment-branch  ((t (:foreground ,atom-one-dark-blue :weight bold))))
    `(git-commit-comment-heading ((t (:foreground ,atom-one-dark-orange-2 :weight bold))))
 
+   ;; js2-mode
+   `(js2-function-call ((t (:inherit (font-lock-function-name-face)))))
+   `(js2-function-param ((t (:foreground ,atom-one-dark-mono-1))))
+   `(js2-jsdoc-tag ((t (:foreground ,atom-one-dark-purple))))
+   `(js2-jsdoc-type ((t (:foreground ,atom-one-dark-orange-2))))
+   `(js2-jsdoc-value((t (:foreground ,atom-one-dark-red-1))))
+   `(js2-object-property ((t (:foreground ,atom-one-dark-red-1))))
+
    ;; magit
    `(magit-section-highlight ((t (:background ,atom-one-dark-bg-hl))))
    `(magit-section-heading ((t (:foreground ,atom-one-dark-orange-2 :weight bold))))
@@ -289,6 +297,40 @@
 ;;;;; fill-column-indicator
    `(fci-rule-color ,atom-one-dark-gray)
    ))
+
+(defvar atom-one-dark-theme-force-faces-for-mode t
+  "If t, atom-one-dark-theme will use Face Remapping to alter the theme faces for
+the current buffer based on its mode in an attempt to mimick the Atom One Dark
+Theme from Atom.io as best as possible.
+The reason this is required is because some modes (html-mode, jyaml-mode, ...)
+do not provide the necessary faces to do theming without conflicting with other
+modes.
+Current modes, and their faces, impacted by this variable:
+* js2-mode: font-lock-constant-face, font-lock-doc-face, font-lock-variable-name-face
+")
+
+;; Many modes in Emacs do not define their own faces and instead use standard Emacs faces when it comes to theming.
+;; That being said, to have a real "Atom One Dark Theme" for Emacs, we need to work around this so that these themes look
+;; as much like "Atom One Dark Theme" as possible.  This means using per-buffer faces via "Face Remapping":
+;;
+;;   http://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Remapping.html
+;;
+;; Of course, this might be confusing to some when in one mode they see keywords highlighted in one face and in another
+;; mode they see a different face.  That being said, you can set the `atom-one-dark-theme-force-faces-for-mode` variable to
+;; `nil` to disable this feature.
+(defun atom-one-dark-theme-change-faces-for-mode ()
+  (interactive)
+  (and (eq atom-one-dark-theme-force-faces-for-mode t)
+       (cond
+        ((member major-mode '(js2-mode))
+         ;; atom-one-dark-orange-1
+         (face-remap-add-relative 'font-lock-constant-face :foreground "#D19A66")
+         (face-remap-add-relative 'font-lock-doc-face '(:inherit (font-lock-comment-face)))
+         ;; atom-one-dark-mono-1
+         (face-remap-add-relative 'font-lock-variable-name-face :foreground "#ABB2BF"))
+        )))
+
+(add-hook 'after-change-major-mode-hook 'atom-one-dark-theme-change-faces-for-mode)
 
 ;;;###autoload
 (and load-file-name


### PR DESCRIPTION
This commit adds initial support for js2-mode.  This is not a 100%
complete representation but that is more due to the differences between
how Atom and Emacs theme in general and less about the work.  For the
most part this is straight forward but there is support for
face-remapping to allow for a more accurate theme.  This can be disabled
if necessary and is documented in the source.

For the _face-remapping_, I copied the same approach I used in my own
_Atom Dark_ theme for emacs: https://github.com/whitlockjc/atom-dark-theme-emacs/blob/master/atom-dark-theme.el

**Note:** I was unable to make the code within the face-remapping hook work with your `atom-one-dark-with-color-variables` macro so I just copied/pasted the style _(with comment)_ instead of referencing the theme-specific color by name.  If I can figure this out, I will update the PR.
