### PR TITLE
Set linum and hlinum colours

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -21,6 +21,8 @@
     ("atom-one-dark-bg"       . "#282C34")
     ("atom-one-dark-bg-1"     . "#121417")
     ("atom-one-dark-bg-hl"    . "#2F343D")
+    ("atom-one-dark-gutter"   . "#666D7A")
+    ("atom-one-dark-accent"   . "#AEB9F5")
     ("atom-one-dark-mono-1"   . "#ABB2BF")
     ("atom-one-dark-mono-2"   . "#828997")
     ("atom-one-dark-mono-3"   . "#5C6370")
@@ -281,6 +283,11 @@
    `(term-color-red ((t :foreground ,atom-one-dark-red-1)))
    `(term-color-white ((t :foreground ,atom-one-dark-fg)))
    `(term-color-yellow ((t (:foreground ,atom-one-dark-orange-1))))
+
+   ;; linum
+   `(linum ((t (:foreground ,atom-one-dark-gutter :background ,atom-one-dark-bg))))
+   ;; hlinum
+   `(linum-highlight-face ((t (:foreground ,atom-one-dark-accent :background ,atom-one-dark-bg))))
    ))
 
 (atom-one-dark-with-color-variables


### PR DESCRIPTION
Match the original colours in linum mode. Also set the current number
face used by hlinum.

Fixes #22 

Before - top
After - botom
![2016-10-15-230719_107x222_escrotum](https://cloud.githubusercontent.com/assets/2960312/19413060/31ea1590-932c-11e6-9f0b-a54cab30e400.png)
