### PR TITLE
Add color-variables for "latex-mode" and "helm-swoop"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Joel Holdbrooks <cjholdbrooks@gmail.com>
 Filip Szymański <@fszymanski>
 George Thomas <@thegeorgeous>
 Romanos <@rski>
+Yusaku Torii <@jabberwocky0139>

--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -170,6 +170,9 @@
    `(helm-grep-lineno ((t (:foreground ,atom-one-dark-mono-2))))
    `(helm-grep-finish ((t (:foreground ,atom-one-dark-red-1))))
    `(helm-grep-match ((t (:foreground nil :background nil :inherit helm-match))))
+   `(helm-swoop-target-line-block-face ((t (:background ,atom-one-dark-mono-3 :foreground "#222222"))))
+   `(helm-swoop-target-line-face ((t (:background ,atom-one-dark-mono-3 :foreground "#222222"))))
+   `(helm-swoop-target-word-face ((t (:background ,atom-one-dark-purple :foreground "#ffffff"))))
 
    ;; git-commit
    `(git-commit-comment-action  ((t (:foreground ,atom-one-dark-green :weight bold))))
@@ -296,6 +299,14 @@
    `(linum ((t (:foreground ,atom-one-dark-gutter :background ,atom-one-dark-bg))))
    ;; hlinum
    `(linum-highlight-face ((t (:foreground ,atom-one-dark-accent :background ,atom-one-dark-bg))))
+
+   ;; latex-mode
+   `(font-latex-sectioning-0-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))
+   `(font-latex-sectioning-1-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))
+   `(font-latex-sectioning-2-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))
+   `(font-latex-sectioning-3-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))
+   `(font-latex-sectioning-4-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))
+   `(font-latex-sectioning-5-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))
    ))
 
 (atom-one-dark-with-color-variables


### PR DESCRIPTION
Hi,

I added faces for `latex-mode` and [`helm-swoop`](https://github.com/ShingoFukuyama/helm-swoop). 

**latex-mode**
Under the [issue#24](https://github.com/jonathanchu/atom-one-dark-theme/issues/24), I added faces of section(and chapter, subsection, subsubsection...). Font sizes are fixed and colors are set properly.

**helm-swoop**
I added faces of target.

I intended to adjust them to this atom theme. But if you think these configurations are not proper, please change them as you like.
