### PR TITLE
Add color-variables for "helm", "latex-mode", "org-mode" and "undo-tree"

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -173,6 +173,8 @@
    `(helm-swoop-target-line-block-face ((t (:background ,atom-one-dark-mono-3 :foreground "#222222"))))
    `(helm-swoop-target-line-face ((t (:background ,atom-one-dark-mono-3 :foreground "#222222"))))
    `(helm-swoop-target-word-face ((t (:background ,atom-one-dark-purple :foreground "#ffffff"))))
+   `(helm-locate-finish ((t (:foreground ,atom-one-dark-green))))
+   `(info-menu-star ((t (:foreground ,atom-one-dark-red-1))))
 
    ;; git-commit
    `(git-commit-comment-action  ((t (:foreground ,atom-one-dark-green :weight bold))))
@@ -307,6 +309,20 @@
    `(font-latex-sectioning-3-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))
    `(font-latex-sectioning-4-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))
    `(font-latex-sectioning-5-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))
+   `(font-latex-bold-face ((t (:foreground ,atom-one-dark-green :weight bold))))
+   `(font-latex-italic-face ((t (:foreground ,atom-one-dark-green))))
+   `(font-latex-warning-face ((t (:foreground ,atom-one-dark-red-1))))
+   `(font-latex-doctex-preprocessor-face ((t (:foreground ,atom-one-dark-cyan))))
+
+   ;; org-mode
+   `(org-date ((t (:foreground ,atom-one-dark-cyan))))
+   `(org-footnote ((t (:foreground ,atom-one-dark-cyan))))
+   `(org-sexp-date ((t (:foreground ,atom-one-dark-cyan))))
+
+   ;; undo-tree
+   `(undo-tree-visualizer-current-face ((t (:foreground ,atom-one-dark-red-1))))
+   `(undo-tree-visualizer-register-face ((t (:foreground ,atom-one-dark-orange-1))))
+   `(undo-tree-visualizer-unmodified-face ((t (:foreground ,atom-one-dark-cyan))))
    ))
 
 (atom-one-dark-with-color-variables


### PR DESCRIPTION
Hi, 

I added color variables for `helm-locate`, `helm-info-*`, `latex-mode`, `org-mode`, and `undo-tree`. I often use these modes and commands, and these font color themes bother me a little.
(I should have added "latex-mode" configurations on the previous pull request (;^_^).

I don't know whether it is proper to set `info-menu-star` configration on the helm comfiguration area(I usually use info-menu through `helm-info-*`). If you think it is improper, please tell me about that. I don't care to change it. 