### PR TITLE
Add "line-number" and "line-number-current-line"

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -36,8 +36,7 @@
     ("atom-one-dark-bg"       . "#282C34")
     ("atom-one-dark-bg-1"     . "#121417")
     ("atom-one-dark-bg-hl"    . "#2F343D")
-    ("atom-one-dark-gutter"   . "#666D7A")
-    ("atom-one-dark-accent"   . "#AEB9F5")
+    ("atom-one-dark-gutter"   . "#636D83")
     ("atom-one-dark-mono-1"   . "#ABB2BF")
     ("atom-one-dark-mono-2"   . "#828997")
     ("atom-one-dark-mono-3"   . "#5C6370")
@@ -334,10 +333,10 @@
    ;; linum
    `(linum ((t (:foreground ,atom-one-dark-gutter :background ,atom-one-dark-bg))))
    ;; hlinum
-   `(linum-highlight-face ((t (:foreground ,atom-one-dark-accent :background ,atom-one-dark-bg))))
+   `(linum-highlight-face ((t (:foreground ,atom-one-dark-fg :background ,atom-one-dark-bg))))
    ;; native line numbers (emacs version >=26)
    `(line-number ((t (:foreground ,atom-one-dark-gutter :background ,atom-one-dark-bg))))
-   `(line-number-current-line ((t (:foreground ,atom-one-dark-accent :background ,atom-one-dark-bg))))
+   `(line-number-current-line ((t (:foreground ,atom-one-dark-fg :background ,atom-one-dark-bg))))
 
    ;; latex-mode
    `(font-latex-sectioning-0-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))

--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -335,6 +335,9 @@
    `(linum ((t (:foreground ,atom-one-dark-gutter :background ,atom-one-dark-bg))))
    ;; hlinum
    `(linum-highlight-face ((t (:foreground ,atom-one-dark-accent :background ,atom-one-dark-bg))))
+   ;; native line numbers (emacs version >=26)
+   `(line-number ((t (:foreground ,atom-one-dark-gutter :background ,atom-one-dark-bg))))
+   `(line-number-current-line ((t (:foreground ,atom-one-dark-accent :background ,atom-one-dark-bg))))
 
    ;; latex-mode
    `(font-latex-sectioning-0-face ((t (:foreground ,atom-one-dark-blue :height 1.0))))


### PR DESCRIPTION
Emacs version 26 adds optional native display of line numbers in the
buffer.

See: https://github.com/emacs-mirror/emacs/blob/emacs-26/etc/NEWS#L492