### PR TITLE
Match mode-line colors to Atom status-bar

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -49,8 +49,8 @@
     ("atom-one-dark-orange-1" . "#D19A66")
     ("atom-one-dark-orange-2" . "#E5C07B")
     ("atom-one-dark-gray"     . "#3E4451")
-    ("atom-one-dark-silver"   . "#AAAAAA")
-    ("atom-one-dark-black"    . "#0F1011"))
+    ("atom-one-dark-silver"   . "#9DA5B4")
+    ("atom-one-dark-black"    . "#21252B"))
   "List of Atom One Dark colors.")
 
 (defmacro atom-one-dark-with-color-variables (&rest body)
@@ -96,10 +96,10 @@
    `(font-lock-warning-face ((t (:foreground ,atom-one-dark-mono-3 :bold t))))
 
    ;; mode-line
-   `(mode-line ((t (:background ,atom-one-dark-black :foreground ,atom-one-dark-silver))))
+   `(mode-line ((t (:background ,atom-one-dark-black :foreground ,atom-one-dark-silver :box (:color "#181A1F" :line-width 1)))))
    `(mode-line-buffer-id ((t (:weight bold))))
    `(mode-line-emphasis ((t (:weight bold))))
-   `(mode-line-inactive ((t (:background ,atom-one-dark-gray))))
+   `(mode-line-inactive ((t (:background ,atom-one-dark-gray :foreground ,atom-one-dark-mono-3))))
 
    ;; ido
    `(ido-first-match ((t (:foreground ,atom-one-dark-purple :weight bold))))

--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -50,7 +50,8 @@
     ("atom-one-dark-orange-2" . "#E5C07B")
     ("atom-one-dark-gray"     . "#3E4451")
     ("atom-one-dark-silver"   . "#9DA5B4")
-    ("atom-one-dark-black"    . "#21252B"))
+    ("atom-one-dark-black"    . "#21252B")
+    ("atom-one-dark-border"   . "#181A1F"))
   "List of Atom One Dark colors.")
 
 (defmacro atom-one-dark-with-color-variables (&rest body)
@@ -96,7 +97,7 @@
    `(font-lock-warning-face ((t (:foreground ,atom-one-dark-mono-3 :bold t))))
 
    ;; mode-line
-   `(mode-line ((t (:background ,atom-one-dark-black :foreground ,atom-one-dark-silver :box (:color "#181A1F" :line-width 1)))))
+   `(mode-line ((t (:background ,atom-one-dark-black :foreground ,atom-one-dark-silver :box (:color ,atom-one-dark-border :line-width 1)))))
    `(mode-line-buffer-id ((t (:weight bold))))
    `(mode-line-emphasis ((t (:weight bold))))
    `(mode-line-inactive ((t (:background ,atom-one-dark-gray :foreground ,atom-one-dark-mono-3))))


### PR DESCRIPTION
I thought it would be nice if the mode-line colors matched the Atom status-bar.

This commit:

- Matches the colors of the active mode-line to the status-bar by
  updating `atom-one-dark-silver` and `atom-one-dark-black` to values
  found by inspecting the Atom editor.

- Adds a border (in GUI Emacs) around the active mode-line,
  matched to the border color of the Atom status-bar.

- Helps to differentiate between the active and inactive
  mode-lines by dimming the foreground color of the inactive mode-line.

I used a hard-coded value for the color of the active mode-line box border, since I don't see much use for it in other places. If you prefer, it could be defined as `atom-one-dark-border` or whatever you think makes sense.
