### PR TITLE
Improve line number color matching to Atom editor

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -36,7 +36,7 @@
     ("atom-one-dark-bg"       . "#282C34")
     ("atom-one-dark-bg-1"     . "#121417")
     ("atom-one-dark-bg-hl"    . "#2F343D")
-    ("atom-one-dark-gutter"   . "#636D83")
+    ("atom-one-dark-gutter"   . "#4B5363")
     ("atom-one-dark-mono-1"   . "#ABB2BF")
     ("atom-one-dark-mono-2"   . "#828997")
     ("atom-one-dark-mono-3"   . "#5C6370")


### PR DESCRIPTION

Sorry about the inundation of pull requests. :grimacing: I didn't take Atom's `opacity` setting into account when updating the line number color in 81df7da. The opacity is not set in the same place as `color`, which is why I missed it. :anguished:

I made some screenshots for comparison. The shots are taken on a Mac:

- Foreground: Emacs, version 26.0.90, using native line numbers and running in iTerm2
- Background: Atom, version 1.23.3
- The *current line number* is `132`

Although we can match Atom's line number colors exactly (when adjusting for opacity in both *line number* and *current line number*) as seen in the following screenshot:

*line number*: `#4b5363` *current line number*: `#777c87`
![exact-to-atom](https://user-images.githubusercontent.com/286057/34840042-c580d0dc-f6d1-11e7-802d-62fb0990b611.png)

I think keeping `atom-one-dark-fg` for the *current line number* makes it easier to distinguish. **This is what this pull request looks like**:

*line number*: `#4b5363` *current line number*: `atom-one-dark-fg`
![fg-for-current-line-number](https://user-images.githubusercontent.com/286057/34840078-e4f954fc-f6d1-11e7-9962-9d17ac27911f.png)

And for reference, here is 81df7da:

*line number*: `#636d83` *current line number*: `atom-one-dark-fg`
![master-51d197b](https://user-images.githubusercontent.com/286057/34840143-0f6caab8-f6d2-11e7-82c1-459157e411bd.png)

Talk about overthinking something! :smile:
