### PR TITLE
Try boxed attribute for enabled/disabled breakpoint lines

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -362,8 +362,8 @@
 ))
    '(realgud-bp-enabled-face       ((t (:inherit (error)))))
    `(realgud-bp-disabled-face      ((t (:inherit (secondary-selection)))))
-   `(realgud-bp-line-enabled-face  ((t (:foreground ,atom-one-dark-red-1))))
-   `(realgud-bp-line-disabled-face ((t (:inherit (secondary-selection)))))
+   `(realgud-bp-line-enabled-face  ((t (:box (:color ,atom-one-dark-red-1)))))
+   `(realgud-bp-line-disabled-face ((t (:box (:color ,atom-one-dark-gray)))))
    `(realgud-line-number           ((t (:foreground ,atom-one-dark-mono-2))))
    `(realgud-backtrace-number      ((t (:inherit (secondary-selection)))))
 


### PR DESCRIPTION
Hi again.  Thanks for adding realgud and the  kind words.

Here is a small change for your consideration: using boxed attributes for enabled and disabled breakpoints. Here is how things currently look: 

![atom-current](https://user-images.githubusercontent.com/8851/34913718-2491dba4-f8d3-11e7-8f5f-5b9df16c2864.png)

and with boxed attributes: 

![atom-proposed](https://user-images.githubusercontent.com/8851/34913720-2ebabd26-f8d3-11e7-9640-7c51cdb3d33c.png)

Since I am very poor at design, please feel free to keep things as is if you prefer that or change as you see fit. 

Thanks.

