### PR TITLE
Update atom-one-dark-bg-hl to match Atom theme

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -35,7 +35,7 @@
     ("atom-one-dark-fg"       . "#ABB2BF")
     ("atom-one-dark-bg"       . "#282C34")
     ("atom-one-dark-bg-1"     . "#121417")
-    ("atom-one-dark-bg-hl"    . "#2F343D")
+    ("atom-one-dark-bg-hl"    . "#2C323C")
     ("atom-one-dark-gutter"   . "#4B5363")
     ("atom-one-dark-mono-1"   . "#ABB2BF")
     ("atom-one-dark-mono-2"   . "#828997")


### PR DESCRIPTION
Hi @jonathanchu 

Based on the gists referred to in this comment, https://github.com/jonathanchu/atom-one-dark-theme/issues/15#issuecomment-362100868, here is an exact match for the Atom cursor line.

It's not that big of a difference, more for the sake of completeness. ✅ 😄 