### PR TITLE
Match vertical-border to Atom and improve mode-line colors

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -80,7 +80,7 @@
    `(region ((t (:background ,atom-one-dark-gray))))
    `(highlight ((t (:background ,atom-one-dark-gray))))
    `(hl-line ((t (:background ,atom-one-dark-bg-hl))))
-   `(vertical-border ((t (:foreground ,atom-one-dark-mono-3))))
+   `(vertical-border ((t (:background ,atom-one-dark-border :foreground ,atom-one-dark-border))))
    `(secondary-selection ((t (:background ,atom-one-dark-bg-1))))
    `(query-replace ((t (:inherit (isearch)))))
    `(minibuffer-prompt ((t (:foreground ,atom-one-dark-silver))))
@@ -102,7 +102,7 @@
    `(mode-line ((t (:background ,atom-one-dark-black :foreground ,atom-one-dark-silver :box (:color ,atom-one-dark-border :line-width 1)))))
    `(mode-line-buffer-id ((t (:weight bold))))
    `(mode-line-emphasis ((t (:weight bold))))
-   `(mode-line-inactive ((t (:background ,atom-one-dark-gray :foreground ,atom-one-dark-mono-3))))
+   `(mode-line-inactive ((t (:background ,atom-one-dark-border :foreground ,atom-one-dark-gray :box (:color ,atom-one-dark-border :line-width 1)))))
 
    ;; ido
    `(ido-first-match ((t (:foreground ,atom-one-dark-purple :weight bold))))


### PR DESCRIPTION
Hi @jonathanchu,

This commit sets the vertical border color to match Atom and tweaks the color of inactive mode lines.  Thanks to your foresight, we added Atom's border color as a variable, so it was a simple edit.

This is what Atom looks like with splits:

![atom](https://user-images.githubusercontent.com/286057/36882915-9277921c-1da4-11e8-96ae-ccebaaec5701.png)

Atom only has one mode line, but if we think of inactive mode lines in Emacs as the horizontal borders in Atom, we get this (what this commit looks like in GUI Emacs):

![gui-new](https://user-images.githubusercontent.com/286057/36882926-a06ba246-1da4-11e8-8c79-5221b8b8b0a8.png)

This is what the Emacs theme looks like before this commit (current master):

![gui-original](https://user-images.githubusercontent.com/286057/36882936-ad2b06a2-1da4-11e8-888c-43765fd96fff.png)

For reference, I'm attaching before and after shots of full color and 256 color terminals.

Emacs in full color terminal, before:

![full-color-term-orig](https://user-images.githubusercontent.com/286057/36883028-5768823e-1da5-11e8-9d32-d4da6605b39e.png)

Emacs in full color terminal, after this commit:

![full-color-term-new](https://user-images.githubusercontent.com/286057/36883034-61acabbc-1da5-11e8-86ce-f68e3bb33623.png)

Emacs in 256 color terminal, before:

![256color-term-orig](https://user-images.githubusercontent.com/286057/36883042-686e068a-1da5-11e8-99a0-ccbf6977d3e9.png)

Emacs in 256 terminal, after this commit:

![256color-term-new](https://user-images.githubusercontent.com/286057/36883048-6e3bb74c-1da5-11e8-98f0-fa186eedf67f.png)

I think this is a better match for the original Atom theme and a more logical approach. 

What do you think?
