### PR TITLE
Updated the weight of font-lock-keyword-face

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -90,7 +90,7 @@
    `(font-lock-comment-delimiter-face ((default (:inherit (font-lock-comment-face)))))
    `(font-lock-doc-face ((t (:inherit (font-lock-string-face)))))
    `(font-lock-function-name-face ((t (:foreground ,atom-one-dark-blue))))
-   `(font-lock-keyword-face ((t (:foreground ,atom-one-dark-purple))))
+   `(font-lock-keyword-face ((t (:foreground ,atom-one-dark-purple :weight normal))))
    `(font-lock-preprocessor-face ((t (:foreground ,atom-one-dark-mono-2))))
    `(font-lock-string-face ((t (:foreground ,atom-one-dark-green))))
    `(font-lock-type-face ((t (:foreground ,atom-one-dark-orange-2))))


### PR DESCRIPTION
Just doing some tweaks to try and get it closer to the current atom syntax theme.  I think it looks a bit closer.  I'm running Hack-11 as my font and having it as the bold weight seemed a bit much.