### PR TITLE
Add some basic theming to Emacs tabs

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -664,6 +664,11 @@
   `(undo-tree-visualizer-current-face ((t (:foreground ,atom-one-dark-red-1))))
   `(undo-tree-visualizer-register-face ((t (:foreground ,atom-one-dark-orange-1))))
   `(undo-tree-visualizer-unmodified-face ((t (:foreground ,atom-one-dark-cyan))))
+
+  ;; tab-bar-mode
+  `(tab-bar-tab-inactive ((t (:background ,atom-one-dark-bg-hl :foreground ,atom-one-dark-fg))))
+  `(tab-bar-tab          ((t (:background ,atom-one-dark-bg :foreground ,atom-one-dark-purple))))
+  `(tab-bar              ((t (:background ,atom-one-dark-bg-hl))))
   ))
 
 (atom-one-dark-with-color-variables


### PR DESCRIPTION
There is a native tab mode on the Emacs master branch now. This update provides some basic theming to keep the visuals in-step with other effects provided by the theme. The active tab is slightly darker than other tabs, and has a purple label -- just like the major mode label in Spaceline. 

![atom-one-dark](https://user-images.githubusercontent.com/33698018/66273058-17ff5c00-e836-11e9-9a21-3bdf9c85c06a.png)
