### PR TITLE
Add support for tab-line mode

### DIFF
--- a/atom-one-dark-theme.el
+++ b/atom-one-dark-theme.el
@@ -677,6 +677,13 @@
    `(tab-bar-tab-inactive ((t (:background ,atom-one-dark-bg-hl :foreground ,atom-one-dark-fg))))
    `(tab-bar-tab          ((t (:background ,atom-one-dark-bg :foreground ,atom-one-dark-purple))))
    `(tab-bar              ((t (:background ,atom-one-dark-bg-hl))))
+
+   ;; tab-line-mode
+   `(tab-line ((t (:foreground ,atom-one-dark-fg :background ,atom-one-dark-black :box (:line-width 1 :color ,atom-one-dark-black)))))
+   `(tab-line-tab-current ((t (:foreground ,atom-one-dark-fg :background ,atom-one-dark-bg :box (:line-width 1 :color ,atom-one-dark-bg) :weight bold))))
+   `(tab-line-tab-inactive ((t (:foreground ,atom-one-dark-fg :background ,atom-one-dark-black :box (:line-width 1 :color ,atom-one-dark-black)))))
+   `(tab-line-tab ((t (:foreground ,atom-one-dark-fg :background ,atom-one-dark-black :box (:line-width 1 :color ,atom-one-dark-black)))))
+   `(tab-line-highlight ((t (:foreground ,atom-one-dark-fg :background ,atom-one-dark-bg :box (:line-width 1 :color ,atom-one-dark-bg)))))
    ))
 
 (atom-one-dark-with-color-variables


### PR DESCRIPTION
There is a `tab-line-mode` in the main branch of Emacs now for showing the buffer history within a window as tabs.

This PR adds theme support for it, in the vein of #58. Please feel free to change it as you see fit before merging.